### PR TITLE
Added load of AWS_SESSION_TOKEN from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,8 @@ can be specified in one of two ways:
 ```javascript
 aws4.sign(requestOptions, {
   secretAccessKey: "<your-secret-access-key>",
-  accessKeyId: "<your-access-key-id>"
+  accessKeyId: "<your-access-key-id>",
+  sessionToken: "<your-session-token>"
 })
 ```
 
@@ -369,9 +370,13 @@ aws4.sign(requestOptions, {
 ```
 export AWS_SECRET_ACCESS_KEY="<your-secret-access-key>"
 export AWS_ACCESS_KEY_ID="<your-access-key-id>"
+export AWS_SESSION_TOKEN="<your-session-token>"
 ```
 
 (will also use `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` if available)
+
+The `sessionToken` property and `AWS_SESSION_TOKEN` environment variable are optional for signing
+with [IAM STS temporary credentials](http://docs.aws.amazon.com/STS/latest/UsingSTS/using-temp-creds.html).
 
 Installation
 ------------

--- a/aws4.js
+++ b/aws4.js
@@ -159,7 +159,8 @@ RequestSigner.prototype.defaultCredentials = function() {
   var env = process.env
   return {
     accessKeyId:     env.AWS_ACCESS_KEY_ID     || env.AWS_ACCESS_KEY,
-    secretAccessKey: env.AWS_SECRET_ACCESS_KEY || env.AWS_SECRET_KEY
+    secretAccessKey: env.AWS_SECRET_ACCESS_KEY || env.AWS_SECRET_KEY,
+    sessionToken:    env.AWS_SESSION_TOKEN
   }
 }
 


### PR DESCRIPTION
If AWS_SESSION_TOKEN is present in the environment, add it to the default credentials. This would avoid passing the entire credentials argument when working with temporary credentials.
