### PR TITLE
Small fix for query string encoding

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -15,6 +15,18 @@ function hash(string, encoding) {
   return crypto.createHash('sha256').update(string, 'utf8').digest(encoding)
 }
 
+this.uriEscape = function(str) {
+  // RFC-3986 fix
+  if (str) {
+    str = str.replace(/!/g, '%21');
+    str = str.replace(/\*/g, '%2A');
+    str = str.replace(/\(/g, '%28');
+    str = str.replace(/\)/g, '%29');
+    str = str.replace(/'/g, '%27');
+  }
+  return str;
+}
+
 // request: { path | body, [host], [method], [headers], [service], [region] }
 // credentials: { accessKeyId, secretAccessKey, [sessionToken] }
 function RequestSigner(request, credentials) {
@@ -176,6 +188,7 @@ RequestSigner.prototype.canonicalString = function() {
       obj[key] = Array.isArray(query[key]) ? query[key].sort() : query[key]
       return obj
     }, {}))
+    queryStr = uriEscape(queryStr)
   }
   return [
     this.request.method || 'GET',

--- a/test/fast.js
+++ b/test/fast.js
@@ -157,6 +157,46 @@ describe('aws4', function() {
     })
   })
 
+  describe('#uriEscape()', function() {
+    var uriEscape = function (str) {
+      // querystring.stringify/encodeURIComponent is not enough
+      // for proper escaping of query string values
+      // hence we need to apply this
+      str = encodeURIComponent(str)
+      if (str) {
+        str = str.replace(/!/g, '%21');
+        str = str.replace(/\*/g, '%2A');
+        str = str.replace(/\(/g, '%28');
+        str = str.replace(/\)/g, '%29');
+        str = str.replace(/'/g, '%27');
+      }
+      return str;
+    };
+
+    // copied from AWS SDK for Node.js
+    it('escapes spaces as %20', function() {
+      return uriEscape('a b').should.equal('a%20b')
+    });
+    it('escapes + as %2B', function() {
+      return uriEscape('a+b').should.equal('a%2Bb')
+    });
+    it('escapes / as %2F', function() {
+      return uriEscape('a/b').should.equal('a%2Fb')
+    });
+    it('escapes \' as %27', function() {
+      return uriEscape('a\'b').should.equal('a%27b')
+    });
+    it('escapes * as %2A', function() {
+      return uriEscape('a*b').should.equal('a%2Ab')
+    });
+    it('does not escape ~', function() {
+      return uriEscape('a~b').should.equal('a~b')
+    });
+    return it('encodes utf8 characters', function() {
+      return uriEscape('ёŝ').should.equal('%D1%91%C5%9D')
+    });
+  });
+
   describe('with AWS test suite', function() {
     var CREDENTIALS = {
       accessKeyId: 'AKIDEXAMPLE',


### PR DESCRIPTION
Hey thanks for this handy module!
I've recently noticed that it wasn't escaping some characters properly i.e. `*, !, (, ), '` so I added the method `uriEscape()` to do that.