### PR TITLE
handle date headers correctly

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -76,8 +76,8 @@ RequestSigner.prototype.sign = function() {
     if (this.service === 's3' && !query['X-Amz-Expires'])
       query['X-Amz-Expires'] = 86400
 
-    if (query['X-Amz-Date'])
-      this.datetime = query['X-Amz-Date']
+    if (query['X-Amz-Date'] || query['x-amz-date'])
+      this.datetime = query['X-Amz-Date'] || query['x-amz-date']
     else
       query['X-Amz-Date'] = this.getDateTime()
 
@@ -105,8 +105,8 @@ RequestSigner.prototype.sign = function() {
       if (this.service === 's3')
         headers['X-Amz-Content-Sha256'] = hash(this.request.body || '', 'hex')
 
-      if (headers['X-Amz-Date'])
-        this.datetime = headers['X-Amz-Date']
+      if (headers['X-Amz-Date'] || headers['x-amz-date'] || headers['date'] || headers['Date'])
+        this.datetime = headers['X-Amz-Date'] || headers['x-amz-date'] || headers['date'] || headers['Date']
       else
         headers['X-Amz-Date'] = this.getDateTime()
     }


### PR DESCRIPTION
AWS Sig V4 can use the "Date" or "date" header instead of "x-amz-date" in case the latter is absent.

This fixes the way aws4 handles the date header, and also takes care of case-insensitivity.

For reference: http://docs.aws.amazon.com/general/latest/gr/sigv4-date-handling.html