### PR TITLE
Bugfix for get it working with uri that has *

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -186,9 +186,11 @@ RequestSigner.prototype.canonicalString = function() {
       return obj
     }, {})).replace(/[!'()*]/g, function(c) { return '%' + c.charCodeAt(0).toString(16).toUpperCase() })
   }
+  // AWS request * to be encoded, it migth be more chars that also request to be encoded.
+  var uri = (url.resolve('/', pathStr.replace(/\/{2,}/g, '/')) || '/').replace(/\*/g, '%2A');
   return [
     this.request.method || 'GET',
-    url.resolve('/', pathStr.replace(/\/{2,}/g, '/')) || '/',
+    uri,
     queryStr,
     this.canonicalHeaders() + '\n',
     this.signedHeaders(),


### PR DESCRIPTION
Bugfix in canonicalString  for get it working with uri that has *, I have a use case for this to get it working with AWS elasticsearch service.