### PR TITLE
Allow pre-computing bodyHash

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -115,7 +115,7 @@ RequestSigner.prototype.prepareRequest = function() {
         headers['X-Amz-Security-Token'] = this.credentials.sessionToken
 
       if (this.service === 's3')
-        headers['X-Amz-Content-Sha256'] = hash(this.request.body || '', 'hex')
+        headers['X-Amz-Content-Sha256'] = this.request.bodyHash || hash(this.request.body || '', 'hex')
 
       if (headers['X-Amz-Date'])
         this.datetime = headers['X-Amz-Date']
@@ -198,7 +198,7 @@ RequestSigner.prototype.canonicalString = function() {
       decodeSlashesInPath = this.service === 's3',
       firstValOnly = this.service === 's3',
       bodyHash = this.service === 's3' && this.request.signQuery ?
-        'UNSIGNED-PAYLOAD' : hash(this.request.body || '', 'hex')
+        'UNSIGNED-PAYLOAD' : this.request.bodyHash || hash(this.request.body || '', 'hex')
 
   if (query) {
     queryStr = encodeRfc3986(querystring.stringify(Object.keys(query).sort().reduce(function(obj, key) {


### PR DESCRIPTION
I'm using aws4 to sign browser multipart uploads on my server. I don't want to send the request body to the server but only the pre-computed content hash. This pull requests enables sending `bodyHash` as a request parameter.
