### PR TITLE
headers: Host header should also handle ports if specified.

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -45,6 +45,14 @@ function RequestSigner(request, credentials) {
 
   if (!headers.Host && !headers.host)
     headers.Host = request.hostname || request.host || this.createHost()
+  // Handle this specially for AWS S3 compatible servers which support signature v4.
+  // If port is specified use it diligently.
+  if (request.port && this.service === 's3') {
+    if ((request.protocol === 'http:' && request.port !== 80) ||
+        (request.protocol === 'https:' && request.port !== 443)) {
+      headers.Host = headers.Host + ':' + request.port
+    }
+  }
   if (!request.hostname && !request.host)
     request.hostname = headers.Host || headers.host
 }

--- a/test/fast.js
+++ b/test/fast.js
@@ -90,6 +90,26 @@ describe('aws4', function() {
     })
   })
 
+  describe('$sign() with AWS S3 compatible server at port 9000', function() {
+    it('should use passed in values', function() {
+      var headers = {
+        'X-Amz-Date': iso
+      }
+      var cred = {accessKeyId: 'A', secretAccessKey: 'B'},
+          opts = {service: 's3', host: 'localhost',
+                  protocol: 'http:', port: '9000',
+                  region: 'us-east-1', path: '/foo',
+                  method: 'PUT',
+                  headers: headers
+                 }
+      opts = aws4.sign(opts)
+      opts.headers.Authorization.should.equal(
+        'AWS4-HMAC-SHA256 Credential=ABCDEF/20121226/us-east-1/s3/aws4_request, '+
+        'SignedHeaders=host;x-amz-content-sha256;x-amz-date, ' +
+        'Signature=ae35e53a146502715cbcf69baa7fd5ad4c650f359e039612e14c17b92288f8d6')
+    })
+  })
+
   describe('#sign() with no host or region', function() {
     it('should add hostname and default region', function() {
       var opts = aws4.sign({service: 'sqs'})
@@ -550,4 +570,3 @@ describe('aws4', function() {
     })
   })
 })
-


### PR DESCRIPTION
For non-S3 implementations like 'github.com/minio/minio'
which support AWS Signature Version '4' often they are run on
'non-Standard' ports i.e by default minio runs at port '9000'

NodeJS spectacularly misses out on keeping port in-tact with in
the host string, requires one to specify 'port' parameter additionally
in the request options.

Handle this case and make sure to add the custom port provided in options
keep them as part of 'Host' signature header.