### PR TITLE
add API Gateway support

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -77,6 +77,10 @@ RequestSigner.prototype.isSingleRegion = function() {
 }
 
 RequestSigner.prototype.createHost = function() {
+  if(this.request.uri) {
+    this.request.path = url.parse(this.request.uri).path
+    return url.parse(this.request.uri).host
+  }
   var region = this.isSingleRegion() ? '' :
         (this.service === 's3' && this.region !== 'us-east-1' ? '-' : '.') + this.region,
       service = this.service === 'ses' ? 'email' : this.service

--- a/example.js
+++ b/example.js
@@ -370,3 +370,16 @@ request(aws4.sign({
 
 //request(aws4.sign({service: 'sdb', path: '/?Action=ListDomains&Version=2009-04-15'}))
 
+// API Gateway with amazonaws domain name
+request(aws4.sign({
+  uri: 'https://xxxxxx.execute-api.us-west-2.amazonaws.com/v1/required-iam-auth',
+  service: 'execute-api',
+  region: 'us-west-2'
+}))
+
+// API Gateway with custom domain name
+request(aws4.sign({
+  uri: 'https://<custom_domain_name>/required-iam-auth',
+  service: 'execute-api',
+  region: 'us-west-2'
+}))


### PR DESCRIPTION
1.  initial support for AWS API Gateway
2.  [Custom doamin name](http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html) support with API Gateway
3. when _request.uri_ is provided, npm modules like [request](https://www.npmjs.com/package/request) and [request-promise](https://www.npmjs.com/package/request-promise) are also supported
3. examples provided