### PR TITLE
Add support for generating passwords for CodeCommit git access

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,15 @@ request(aws4.sign({
 /*
 (HTTP 202, empty response)
 */
+
+// Generate CodeCommit Git access password
+var signer = new aws4.RequestSigner({
+  service: 'codecommit',
+  host: 'git-codecommit.us-east-1.amazonaws.com',
+  method: 'GIT',
+  path: '/v1/repos/MyAwesomeRepo'
+})
+var password = `${signer.getDateTime()}Z${signer.signature()}`
 ```
 
 API

--- a/test/fast.js
+++ b/test/fast.js
@@ -71,6 +71,21 @@ describe('aws4', function() {
       signer.service.should.equal('sdb')
       signer.region.should.equal('us-east-1')
     })
+
+    it('should not set extra headers for CodeCommit Git access', function() {
+      var signer = new RequestSigner({service: 'codecommit', method: 'GIT', host: 'example.com'})
+      signer.request.headers.should.deepEqual({Host: 'example.com'})
+    })
+
+    it('should not have a "Z" at end of timestamp for CodeCommit Git access', function() {
+      var signer = new RequestSigner({service: 'codecommit', method: 'GIT', host: 'example.com'})
+      signer.getDateTime().should.not.match(/Z$/)
+    })
+
+    it('should not have a body hash in the canonical string for CodeCommit Git access', function() {
+      var signer = new RequestSigner({service: 'codecommit', method: 'GIT', host: 'example.com'})
+      signer.canonicalString().should.match(/\n$/)
+    })
   })
 
   describe('#sign() with no credentials', function() {


### PR DESCRIPTION
CodeCommit passwords for https git access are generated based on the
same underlying techniques used for signing AWS requests. There are just
a few parts omitted. With this change, git access passwords may be
generated by doing the following:

```javascript
let opts = {
      service: 'codecommit',
      region: 'us-east-1',
      host: 'git-codecommit.us-east-1.amazonaws.com',
      method: 'GIT',
      path: '/v1/repos/MyAwesomeRepo'
    }

let signer = new aws4.RequestSigner(opts)

let password = `${signer.getDateTime()}Z${signer.signature()}`
```

Repos can then be cloned by running:

```bash
$ git clone https://<AWS_ACCESS_KEY_ID>:<password>@git-codecommit.us-east-1.amazonaws.com/v1/repos/MyAwesomeRepo
```