### PR TITLE
Add option to allow pre-computing of body hash

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -122,7 +122,7 @@ RequestSigner.prototype.prepareRequest = function() {
         headers['X-Amz-Security-Token'] = this.credentials.sessionToken
 
       if (this.service === 's3')
-        headers['X-Amz-Content-Sha256'] = hash(this.request.body || '', 'hex')
+        headers['X-Amz-Content-Sha256'] = this.request.bodyHash || hash(this.request.body || '', 'hex')
 
       if (headers['X-Amz-Date'])
         this.datetime = headers['X-Amz-Date']
@@ -208,7 +208,7 @@ RequestSigner.prototype.canonicalString = function() {
       decodeSlashesInPath = this.service === 's3',
       firstValOnly = this.service === 's3',
       bodyHash = this.service === 's3' && this.request.signQuery ? 'UNSIGNED-PAYLOAD' :
-        (this.isCodeCommitGit ? '' : hash(this.request.body || '', 'hex'))
+        (this.isCodeCommitGit ? '' : this.request.bodyHash || hash(this.request.body || '', 'hex'))
 
   if (query) {
     queryStr = encodeRfc3986(querystring.stringify(Object.keys(query).sort().reduce(function(obj, key) {

--- a/test/fast.js
+++ b/test/fast.js
@@ -260,6 +260,35 @@ describe('aws4', function() {
     })
   })
 
+  describe('#sign() with bodyHash', function() {
+    it('should use passed hash as X-Amz-Content-Sha256 header', function(){
+      var opts = aws4.sign({
+        service: 's3',
+        method: 'PUT',
+        path: '/some-bucket/file.txt',
+        body: 'Test Body',
+        bodyHash: 'My-Generated-Body-Hash'
+      })
+      opts.headers['X-Amz-Content-Sha256'].should.equal('My-Generated-Body-Hash')
+    })
+    it('should use passed hash in Authorization header', function(){
+      var opts = aws4.sign({
+        service: 's3',
+        method: 'PUT',
+        path: '/some-bucket/file.txt',
+        body: 'Test Body',
+        bodyHash: 'My-Generated-Body-Hash',
+        headers: {
+          Date: date,
+        }
+      })
+      opts.headers.Authorization.should.equal(
+        'AWS4-HMAC-SHA256 Credential=ABCDEF/20121226/us-east-1/s3/aws4_request, ' +
+        'SignedHeaders=content-length;content-type;date;host;x-amz-content-sha256;x-amz-date, ' + 
+        'Signature=afa4074a64185317be81ed18953c6df9ee3a63507e6711ad79a7534f4c0b0c54')
+    })
+  })
+
   describe('#signature() with CodeCommit Git access', function() {
     it('should generate signature correctly', function() {
       var signer = new RequestSigner({


### PR DESCRIPTION
To allow for signing requests which upload large files, pre-computing the body hash by streaming the contents into the hash function is needed.

The bodyHash option will override the use of the body option if its available allowing the user to asynchronously computer the hash of the body before signing the request.