### PR TITLE
Update uri with encoded path if it was part of the original request

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -146,6 +146,11 @@ RequestSigner.prototype.sign = function() {
 
   this.request.path = this.formatPath()
 
+  if (this.request.uri) {
+    var uriParts = this.request.uri.match(/(http(?:s|):\/\/)([^\/]+)(.+)/)
+    this.request.uri = uriParts[1] + uriParts[2] + this.parsedPath.path
+  }
+
   return this.request
 }
 

--- a/aws4.js
+++ b/aws4.js
@@ -148,7 +148,7 @@ RequestSigner.prototype.sign = function() {
 
   if (this.request.uri) {
     var uriParts = this.request.uri.match(/(http(?:s|):\/\/)([^\/]+)(.+)/)
-    this.request.uri = uriParts[1] + uriParts[2] + this.parsedPath.path
+    this.request.uri = uriParts[1] + uriParts[2] + this.request.path
   }
 
   return this.request

--- a/test/fast.js
+++ b/test/fast.js
@@ -300,7 +300,7 @@ describe('aws4', function() {
     it('should update uri in request with encoded path', function() {
       var opts = aws4.sign({
         service: 'dynamodb',
-        path: '/items/module:sub-module:item.collection:12345',
+        path: '/items/module:sub-module:item.collection:12345' + '/?X-Amz-Date=' + iso,
         host: 'host.of.app',
         uri: 'https://host.of.app/items/module:sub-module:item.collection:12345',
         headers: {
@@ -310,7 +310,10 @@ describe('aws4', function() {
         body: '{}',
         signQuery: true
       })
-      opts.uri.should.equal('https://host.of.app/items/module%3Asub-module%3Aitem.collection%3A12345')
+      opts.uri.should.equal('https://host.of.app/items/module%3Asub-module%3Aitem.collection%3A12345/?X-Amz-Date=20121226T061030Z&' +
+        'X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ABCDEF%2F20121226%2Fus-east-1%2Fdynamodb%2Faws4_request&' +
+        'X-Amz-SignedHeaders=content-type%3Bhost%3Bx-amz-target&' +
+        'X-Amz-Signature=4d6b0a644e1b9e98d966f4590b2c1c6c0aff90738522fe988175deb348f0daa9')
     })
   })
 

--- a/test/fast.js
+++ b/test/fast.js
@@ -260,6 +260,60 @@ describe('aws4', function() {
     })
   })
 
+  describe('#sign() without uri', function() {
+    it('should not add add uri to request', function() {
+      var opts = aws4.sign({
+        service: 'dynamodb',
+        path: '/items/module:sub-module:item.collection:12345' + iso,
+        headers: {
+          'Content-Type': 'application/x-amz-json-1.0',
+          'X-Amz-Target': 'DynamoDB_20120810.ListTables'
+        },
+        body: '{}',
+        signQuery: true
+      })
+      if (opts.uri !== undefined) {
+        throw 'uri has been added to the original request'
+      }
+    })
+  })
+
+  describe('#sign() with uri and signQuery=false', function() {
+    it('should update uri in request with encoded path', function() {
+      var opts = aws4.sign({
+        service: 'dynamodb',
+        path: '/items/module:sub-module:item.collection:12345',
+        host: 'host.of.app',
+        uri: 'https://host.of.app/items/module:sub-module:item.collection:12345',
+        headers: {
+          'Content-Type': 'application/x-amz-json-1.0',
+          'X-Amz-Target': 'DynamoDB_20120810.ListTables'
+        },
+        body: '{}',
+        signQuery: false
+      })
+      opts.uri.should.equal('https://host.of.app/items/module%3Asub-module%3Aitem.collection%3A12345')
+    })
+  })
+
+  describe('#sign() with uri and signQuery=true', function() {
+    it('should update uri in request with encoded path', function() {
+      var opts = aws4.sign({
+        service: 'dynamodb',
+        path: '/items/module:sub-module:item.collection:12345',
+        host: 'host.of.app',
+        uri: 'https://host.of.app/items/module:sub-module:item.collection:12345',
+        headers: {
+          'Content-Type': 'application/x-amz-json-1.0',
+          'X-Amz-Target': 'DynamoDB_20120810.ListTables'
+        },
+        body: '{}',
+        signQuery: true
+      })
+      opts.uri.should.equal('https://host.of.app/items/module%3Asub-module%3Aitem.collection%3A12345')
+    })
+  })
+
   describe('#signature() with CodeCommit Git access', function() {
     it('should generate signature correctly', function() {
       var signer = new RequestSigner({


### PR DESCRIPTION
I've run into some issues when the path contained some special characters, like colons: `:`.
In this case, the `path` attribute of the request object was updated to the encoded one, but the `uri` was not, so the keys generated on the server/client side didn't match, and I got an authentication error. 

Though it can be solved by using an encoded `uri`, it would be nice if the updates done to the request are in sync with each other and you don't have to worry about which part will be changed and which won't. This update will be only applied if the `uri` is provided, otherwise it won't change anything.

I'm already using the head of my fork but thought others would also benefit from this change.