### PR TITLE
allow specifying a pre-computed X-Amz-Content-Sha256 value

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -121,7 +121,7 @@ RequestSigner.prototype.prepareRequest = function() {
       if (this.credentials.sessionToken)
         headers['X-Amz-Security-Token'] = this.credentials.sessionToken
 
-      if (this.service === 's3')
+      if (this.service === 's3' && !headers['X-Amz-Content-Sha256'] && !headers['x-amz-content-sha256'])
         headers['X-Amz-Content-Sha256'] = hash(this.request.body || '', 'hex')
 
       if (headers['X-Amz-Date'])


### PR DESCRIPTION
We're looking to use this library in a distributed environment where our server generates a list of generic http requests (e.g. method, url and headers) which get passed to a remote machine which does the actual uploading.  Our remote machine shouldn't have any aws secrets, so we need to generate the list of all these http request's metadata on the server.  Because the server will never have access to the actual content, we need to compute the value of the sha256 for the request body, send that to the server and sign based on that value.

This quick patch allows us to do that by skipping the hashing of the body.  It would also make it easier to use this library to do streaming uploads of things to s3 since it would allow you to use the streams api to compute the sha256 hash, do the signing, then use streams to write to the aws request.