### PR TITLE
Set header Content-Length as a string

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -116,7 +116,7 @@ RequestSigner.prototype.prepareRequest = function() {
         headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8'
 
       if (request.body && !headers['Content-Length'] && !headers['content-length'])
-        headers['Content-Length'] = (Buffer.byteLength(request.body)).toString()
+        headers['Content-Length'] = Buffer.byteLength(request.body).toString()
 
       if (this.credentials.sessionToken && !headers['X-Amz-Security-Token'] && !headers['x-amz-security-token'])
         headers['X-Amz-Security-Token'] = this.credentials.sessionToken

--- a/aws4.js
+++ b/aws4.js
@@ -116,7 +116,7 @@ RequestSigner.prototype.prepareRequest = function() {
         headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8'
 
       if (request.body && !headers['Content-Length'] && !headers['content-length'])
-        headers['Content-Length'] = Buffer.byteLength(request.body)
+        headers['Content-Length'] = (Buffer.byteLength(request.body)).toString()
 
       if (this.credentials.sessionToken && !headers['X-Amz-Security-Token'] && !headers['x-amz-security-token'])
         headers['X-Amz-Security-Token'] = this.credentials.sessionToken


### PR DESCRIPTION
The number format caused a problem on the `node-vault` module: https://github.com/hashicorp/vault/issues/3763#issuecomment-356125993

This should solve it, unless there's any reason to keep it as a number.