### PR TITLE
update host regex to include optional cn group

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -57,7 +57,7 @@ function RequestSigner(request, credentials) {
 }
 
 RequestSigner.prototype.matchHost = function(host) {
-  var match = (host || '').match(/([^\.]+)\.(?:([^\.]*)\.)?amazonaws\.com$/)
+  var match = (host || '').match(/([^\.]+)\.(?:([^\.]*)\.)?amazonaws\.com(\.cn)*$/)
   var hostParts = (match || []).slice(1, 3)
 
   // ES's hostParts are sometimes the other way round, if the value that is expected

--- a/aws4.js
+++ b/aws4.js
@@ -57,7 +57,7 @@ function RequestSigner(request, credentials) {
 }
 
 RequestSigner.prototype.matchHost = function(host) {
-  var match = (host || '').match(/([^\.]+)\.(?:([^\.]*)\.)?amazonaws\.com(\.cn)*$/)
+  var match = (host || '').match(/([^\.]+)\.(?:([^\.]*)\.)?amazonaws\.com(\.cn)?$/)
   var hostParts = (match || []).slice(1, 3)
 
   // ES's hostParts are sometimes the other way round, if the value that is expected


### PR DESCRIPTION
AWS endpoints for china are different from other endpoints, as the host includes an additional .cn (see http://docs.amazonaws.cn/en_us/general/latest/gr/rande.html#cnnorth_region and http://docs.amazonaws.cn/en_us/general/latest/gr/rande.html#cnnorthwest_region).

This PR adds an optional .cn group to the host match regex so that service and region extraction works as expected