### PR TITLE
Include links to aws4-tiny for a minimized browser build

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ aws4
 A small utility to sign vanilla node.js http(s) request options using Amazon's
 [AWS Signature Version 4](http://docs.amazonwebservices.com/general/latest/gr/signature-version-4.html).
 
-Can also be used [in the browser](./browser).
+Can also be used [in the browser](./browser). A minimized build for the browser is available at [aws4-tiny](https://github.com/emdgroup/aws4-tiny).
 
 This signature is supported by nearly all Amazon services, including
 [S3](http://docs.aws.amazon.com/AmazonS3/latest/API/),
@@ -508,7 +508,7 @@ With [npm](http://npmjs.org/) do:
 npm install aws4
 ```
 
-Can also be used [in the browser](./browser).
+Can also be used [in the browser](./browser). A minimized build for the browser is available at [aws4-tiny](https://github.com/emdgroup/aws4-tiny).
 
 Thanks
 ------


### PR DESCRIPTION
Hi @mhart, we've been working hard on a minimized version of aws4 for the browser. [aws4-tiny](https://github.com/emdgroup/aws4-tiny) was born which is just under 17kb in size using a number of polyfills such as sjcl for crypto. Please consider adding the link to your README.

Thanks so much for providing this library. aws4-tiny would not have been possible without it!