### PR TITLE
FIX: mutated headers causing confusion

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -1,6 +1,7 @@
 var aws4 = exports,
     url = require('url'),
     querystring = require('querystring'),
+    objectAssign = require('object-assign'),
     crypto = require('crypto'),
     lru = require('./lru'),
     credentialsCache = lru(1000)
@@ -28,7 +29,7 @@ function RequestSigner(request, credentials) {
 
   if (typeof request === 'string') request = url.parse(request)
 
-  var headers = request.headers = Object.assign({}, (request.headers || {})),
+  var headers = request.headers = objectAssign({}, (request.headers || {})),
       hostParts = this.matchHost(request.hostname || request.host || headers.Host || headers.host)
 
   this.request = request

--- a/aws4.js
+++ b/aws4.js
@@ -28,7 +28,7 @@ function RequestSigner(request, credentials) {
 
   if (typeof request === 'string') request = url.parse(request)
 
-  var headers = request.headers = (request.headers || {}),
+  var headers = request.headers = Object.assign({}, (request.headers || {})),
       hostParts = this.matchHost(request.hostname || request.host || headers.Host || headers.host)
 
   this.request = request

--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
   },
   "scripts": {
     "test": "mocha ./test/fast.js ./test/slow.js -b -t 100s -R list"
+  },
+  "dependencies": {
+    "object-assign": "^4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "license": "MIT",
   "devDependencies": {
     "mocha": "^2.4.5",
-    "should": "^8.2.2"
+    "should": "^13.2.3"
   },
   "scripts": {
     "test": "mocha ./test/fast.js ./test/slow.js -b -t 100s -R list"

--- a/test/fast.js
+++ b/test/fast.js
@@ -97,6 +97,16 @@ describe('aws4', function() {
     })
   })
 
+  describe('#sign() with custom headers', function() {
+    it('should not modify modify provided headers', function() {
+      var cred = {accessKeyId: 'A', secretAccessKey: 'B'};
+      var headers = Object.freeze({Date: date});
+      var opts = aws4.sign({service: 'sqs', headers: headers}, cred);
+
+      should.notStrictEqual(opts.headers, headers);
+    });
+  })
+
   describe('#sign() with credentials', function() {
     it('should use passed in values', function() {
       var cred = {accessKeyId: 'A', secretAccessKey: 'B'},


### PR DESCRIPTION
fixes #78

re. [this issue](https://github.com/mhart/aws4/issues/78) and [subsequent comments](https://github.com/mhart/aws4/issues/78#issuecomment-449093438); when a consumer provides a `headers` object to the request being signed, that object is mutated without notice. This causes issues in scenarios where the `headers` aren't reconstructed on each request, for example:

```js
// this is only stored in memory once
const myDefaultHeaders = {
    'Content-Type': 'application/json'
};

// this function may be called several times
export function signMyRequest(requestBody) {
    const signedRequest = aws4.sign({
        body: requestBody,
        headers: myDefaultHeaders
    }, MY_AWS_CREDS);
}
```

Any subsequent request that the consumer attempts to `sign` will utilize a _"cached"_ copy of the `headers` object, quickly resulting in the signature becoming outdated. 

While this is easy to mitigate if you happen to know about this particular oddity, its relatively straightforward for this module to avoid header mutation altogether.

---

As a bonus, I installed a much newer version of `should` so as to get access to [`should.notStrictEqual`](https://shouldjs.github.io/#should-notstrictequal). Per [the upgrade notes](https://github.com/shouldjs/should.js/wiki/Breaking-changes), I think this should be fine.