### PR TITLE
Fix ordering of query string parameters to match AWS V4 Signing Spec.

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -235,7 +235,22 @@ RequestSigner.prototype.canonicalString = function() {
         reducedQuery[key].forEach(function(val) { encodedQueryPieces.push(encodeRfc3986(encodedPrefix + encodeURIComponent(val))) })
       }
     })
-    queryStr = encodedQueryPieces.sort().join('&')
+    queryStr = encodedQueryPieces.sort(function (a, b) {
+      const a_name = a.split(/=/)[0];
+      const b_name = b.split(/=/)[0];
+      if (a_name < b_name) {
+        return -1
+      } else if (a_name > b_name) {
+        return 1
+      } else {
+        if (a < b) {
+          return -1
+        } else if (a > b) {
+          return 1
+        }
+        return 0
+      }
+    }).join('&');
   }
   if (pathStr !== '/') {
     if (normalizePath) pathStr = pathStr.replace(/\/{2,}/g, '/')

--- a/test/fast.js
+++ b/test/fast.js
@@ -517,6 +517,15 @@ describe('aws4', function() {
       signer.sign().path.should.equal('/%2f?a=%2F&%2F=%2F')
     })
 
+    it('should work with query param order in s3 with key prefix matches', function() {
+      var signer = new RequestSigner({service: 's3', path: '/?search&search-ver=2'})
+      var canonical = signer.canonicalString().split('\n')
+
+      canonical[1].should.equal('/')
+      canonical[2].should.equal('search=&search-ver=2')
+      signer.sign().path.should.equal('/?search=&search-ver=2')
+    })
+
     it('should work with query param order in s3', function() {
       var signer = new RequestSigner({service: 's3', path: '/?a=b&a=B&a=b&a=c'})
       var canonical = signer.canonicalString().split('\n')


### PR DESCRIPTION
When signing a request with query parameters like 

```javascript
{
  path: '/key?select-type=2&select='
}
```

The canonical string produced would be:

```
POST
/key
select-type=2&select=
[extra text elided...]
```

This is incorrect because according the [Signing V4 Spec](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html) specifies:

>To construct the canonical query string, complete the following steps:
>>Sort the parameter names by character code point in ascending order. Parameters with duplicate names should be sorted by value. For example, a parameter name that begins with the uppercase letter F precedes a parameter name that begins with a lowercase letter b.

By calling `
queryStr = encodedQueryPieces.sort().join('&')
` the elements of the array are sorted by their full string values **not the parameter names first then by value**.

Working through the example: `encodedQueryPieces.sort()` is sorting `"select-type=2"` and `"select="`.  Since `"select-type=2"` is lexicographically less than `"select="` (the hyphen character is ranked before the equals sign character) `"select-type=2"` is ranked first, but in actuality it should be ranked last according to the specification saying sorting should occur first by parameter name then by value.

This bug causes signatures to not be verified by AWS since the canonical string does not match what is expected.

My PR corrects this code to sort first by parameter name, then by full parameter value.

The canonical string will now appear as:

```
POST
/key
select=&select-type=2
[extra text elided...]
```
