### PR TITLE
Make STS multi-region

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -108,7 +108,7 @@ RequestSigner.prototype.isSingleRegion = function() {
   // Special case for S3 and SimpleDB in us-east-1
   if (['s3', 'sdb'].indexOf(this.service) >= 0 && this.region === 'us-east-1') return true
 
-  return ['cloudfront', 'ls', 'route53', 'iam', 'importexport', 'sts']
+  return ['cloudfront', 'ls', 'route53', 'iam', 'importexport']
     .indexOf(this.service) >= 0
 }
 


### PR DESCRIPTION
STS has been multi-region for some time now.  It's a [best practice](https://docs.aws.amazon.com/sdkref/latest/guide/feature-sts-regionalized-endpoints.html) to use the regional endpoint for latency and availability reasons.