### PR TITLE
Respect `extraHeaders*` options in canonical headers

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -296,14 +296,21 @@ RequestSigner.prototype.canonicalString = function() {
 }
 
 RequestSigner.prototype.canonicalHeaders = function() {
-  var headers = this.request.headers
+  var headers = this.request.headers,
+      extraHeadersToInclude = this.extraHeadersToInclude,
+      extraHeadersToIgnore = this.extraHeadersToIgnore
   function trimAll(header) {
     return header.toString().trim().replace(/\s+/g, ' ')
   }
-  return Object.keys(headers)
-    .filter(function(key) { return HEADERS_TO_IGNORE[key.toLowerCase()] == null })
-    .sort(function(a, b) { return a.toLowerCase() < b.toLowerCase() ? -1 : 1 })
-    .map(function(key) { return key.toLowerCase() + ':' + trimAll(headers[key]) })
+  return Object.entries(headers)
+    .map(function(entry) { return [entry[0].toLowerCase(), entry[1]] })
+    .filter(function(entry) {
+      var key = entry[0]
+      return extraHeadersToInclude[key] ||
+        (HEADERS_TO_IGNORE[key] == null && !extraHeadersToIgnore[key])
+    })
+    .sort(function(a, b) { return a[0] < b[0] ? -1 : 1 })
+    .map(function(entry) { return entry[0] + ':' + trimAll(entry[1]) })
     .join('\n')
 }
 

--- a/test/fast.js
+++ b/test/fast.js
@@ -407,7 +407,7 @@ describe('aws4', function() {
       opts.headers.Authorization.should.equal(
         'AWS4-HMAC-SHA256 Credential=ABCDEF/20121226/us-east-1/aoss/aws4_request, ' +
         'SignedHeaders=content-type;date;host;x-amz-content-sha256;x-amz-date, ' +
-        'Signature=ade8635c05bfa4961bc28be0b0a0fbfd3d64e79feb1862f822ee6a4517417bcd')
+        'Signature=742b9db3c09dbc6d29dd965fa44ec2d004d4aed4f0f4d179d0ee989c08c9bf06')
     })
   })
 
@@ -427,7 +427,7 @@ describe('aws4', function() {
       opts.headers.Authorization.should.equal(
         'AWS4-HMAC-SHA256 Credential=ABCDEF/20121226/us-east-1/someservice/aws4_request, ' +
         'SignedHeaders=date;host;range;x-amz-date, ' +
-        'Signature=8f3eba7a5743091daae62d00ce1c911c018d48f72dbdf180b15abe701718317a')
+        'Signature=8298a63e47319d57c1af6dfb5e5e5f1b30d2515ad1130d7f240b57ce94302d59')
     })
   })
 

--- a/test/slow.js
+++ b/test/slow.js
@@ -181,14 +181,6 @@ void (async() => {
     },
     body: '{}',
   }, {
-    url: 'https://opsworks.us-east-1.amazonaws.com/',
-    headers: {
-      'Content-Type': 'application/x-amz-json-1.1',
-      'X-Amz-Target': 'OpsWorks_20130218.DescribeStacks',
-      'Accept-Encoding': 'gzip, deflate, br',
-    },
-    body: '{}',
-  }, {
     url: 'https://route53domains.us-east-1.amazonaws.com/',
     headers: {
       'Content-Type': 'application/x-amz-json-1.1',

--- a/test/slow.js
+++ b/test/slow.js
@@ -133,6 +133,29 @@ void (async() => {
     },
     body: '{}',
   }, {
+    url: 'https://dynamodb.us-east-1.amazonaws.com/',
+    headers: {
+      'Content-Type': 'application/x-amz-json-1.0',
+      'X-Amz-Target': 'DynamoDB_20120810.ListTables',
+      'Accept-Encoding': 'gzip, deflate, br',
+      'User-Agent': 'node',
+    },
+    extraHeadersToInclude: {
+      'user-agent': true,
+    },
+    body: '{}',
+  }, {
+    url: 'https://dynamodb.us-east-1.amazonaws.com/',
+    headers: {
+      'Content-Type': 'application/x-amz-json-1.0',
+      'X-Amz-Target': 'DynamoDB_20120810.ListTables',
+      'Accept-Encoding': 'gzip, deflate, br',
+    },
+    extraHeadersToIgnore: {
+      'content-type': true,
+    },
+    body: '{}',
+  }, {
     service: 'appstream',
     url: 'https://appstream2.us-east-1.amazonaws.com/',
     headers: {


### PR DESCRIPTION
The options `extraHeadersToInclude` and `extraHeadersToIgnore` (added in https://github.com/mhart/aws4/commit/180aebd429f4afc3bcf2e370ae683e1b7b23a085) currently control whether headers are present in (or excluded from) signed headers,

https://github.com/mhart/aws4/blob/7e2d1cb64f9f604f5a303cd85f19c32f4f5f131a/aws4.js#L310-L321

but neither option has any effect on the canonical headers:

https://github.com/mhart/aws4/blob/7e2d1cb64f9f604f5a303cd85f19c32f4f5f131a/aws4.js#L298-L308

This causes problems with signature calculation: When AWS computes canonical headers, it uses the list of signed headers to determine what headers to include in the canonical headers. If the list of signed headers does not match the headers in the canonical headers, the signature verification fails (see new integration tests).

---

Fixes #167.
Fixes #157.
Supersedes #158.