### PR TITLE
Added X-Amz-Content-Sha256 for aoss.

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -154,7 +154,7 @@ RequestSigner.prototype.prepareRequest = function() {
       if (this.credentials.sessionToken && !headers['X-Amz-Security-Token'] && !headers['x-amz-security-token'])
         headers['X-Amz-Security-Token'] = this.credentials.sessionToken
 
-      if (this.service === 's3' && !headers['X-Amz-Content-Sha256'] && !headers['x-amz-content-sha256'])
+      if ((this.service === 's3' || this.service === 'aoss') && !headers['X-Amz-Content-Sha256'] && !headers['x-amz-content-sha256'])
         headers['X-Amz-Content-Sha256'] = hash(this.request.body || '', 'hex')
 
       if (headers['X-Amz-Date'] || headers['x-amz-date'])

--- a/test/fast.js
+++ b/test/fast.js
@@ -388,6 +388,38 @@ describe('aws4', function() {
     })
   })
 
+  describe('#sign() without X-Amz-Content-Sha256 header', function() {
+    it('should not add header for any service', function() {
+      var opts = aws4.sign({
+        service: 'aos',
+        method: 'PUT',
+        path: '/some-bucket/file.txt',
+        body: 'Test Body'
+      })
+      opts.headers.should.not.have.property('X-Amz-Content-Sha256')
+    })
+
+    it('should add header for s3', function() {
+      var opts = aws4.sign({
+        service: 's3',
+        method: 'PUT',
+        path: '/some-bucket/file.txt',
+        body: 'Test Body'
+      })
+      opts.headers['X-Amz-Content-Sha256'].should.equal('ae6d8a1c07f438667618879eae74ffab84c236ea5d8ca52d5ca0523cc35e8bb9')
+    })
+
+    it('should add header for an empty body for aoss', function() {
+      var opts = aws4.sign({
+        service: 'aoss',
+        method: 'PUT',
+        path: '/some-bucket/file.txt',
+        body: undefined
+      })
+      opts.headers['X-Amz-Content-Sha256'].should.equal('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+    })
+  })
+
   describe('#sign() with extraHeadersToIgnore', function() {
     it('should generate signature correctly', function() {
       var opts = aws4.sign({


### PR DESCRIPTION
Amazon Serverless OpenSearch requires `X-Amz-Content-Sha256` too.

https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-clients.html

We've been having to add it in a lot of places, e.g. https://github.com/jamesmbourne/aws4-axios/pull/1621 or https://github.com/opensearch-project/opensearch-js/pull/366.